### PR TITLE
Feat/api proxy static files

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -49,6 +49,13 @@ export default defineNuxtConfig({
           url: process.env.DATABASE_URL
         }
       }
+    },
+    routeRules: {
+      '/file/**': { proxy: 'https://stickerly.pstatic.net/**',
+        cache: {
+          maxAge: 60 * 60 // 1 hour
+        }
+      }
     }
   },
 

--- a/server/utils/responseFormatter.ts
+++ b/server/utils/responseFormatter.ts
@@ -31,12 +31,31 @@ export function useFormatter<T = unknown, M = unknown, E = unknown>(
     event.node.res.statusCode = statusCode
   }
 
+  // Helper to recursively replace URLs in any string property
+  function replaceStickerlyUrls<TValue>(obj: TValue): TValue {
+    if (typeof obj === 'string') {
+      return obj.replaceAll(
+        'https://stickerly.pstatic.net/',
+        `${process.env.NUXT_PUBLIC_SITE_URL || ''}file/`
+      ) as TValue
+    } else if (Array.isArray(obj)) {
+      return obj.map(replaceStickerlyUrls) as TValue
+    } else if (obj && typeof obj === 'object') {
+      const newObj = {} as Record<string, unknown>
+      for (const key in obj) {
+        newObj[key] = replaceStickerlyUrls((obj as Record<string, unknown>)[key])
+      }
+      return newObj as TValue
+    }
+    return obj
+  }
+
   if (statusCode < 300) {
     return {
       status: 'success',
       message,
-      data,
-      meta: extra as M,
+      data: replaceStickerlyUrls(data),
+      meta: extra ? replaceStickerlyUrls(extra as M) : undefined,
       timestamp: new Date().toISOString()
     }
   } else {
@@ -44,7 +63,7 @@ export function useFormatter<T = unknown, M = unknown, E = unknown>(
       status: 'error',
       message,
       data: null,
-      errors: extra as E,
+      errors: extra ? replaceStickerlyUrls(extra as E) : undefined,
       timestamp: new Date().toISOString()
     }
   }

--- a/server/utils/responseFormatter.ts
+++ b/server/utils/responseFormatter.ts
@@ -36,7 +36,7 @@ export function useFormatter<T = unknown, M = unknown, E = unknown>(
     if (typeof obj === 'string') {
       return obj.replaceAll(
         'https://stickerly.pstatic.net/',
-        `${process.env.NUXT_PUBLIC_SITE_URL || ''}file/`
+        `${process.env.NUXT_PUBLIC_SITE_URL || '/'}file/`
       ) as TValue
     } else if (Array.isArray(obj)) {
       return obj.map(replaceStickerlyUrls) as TValue


### PR DESCRIPTION
This pull request introduces changes to improve URL handling and caching for a proxy setup and response formatting in the application. The most significant updates include adding route rules for proxying and caching sticker URLs and implementing a helper function to replace URLs dynamically in the response formatter.

### Proxy and caching improvements:
* [`nuxt.config.ts`](diffhunk://#diff-5977891bf10802cdd3cde62f0355105a1662e65b02ae4fb404a27bb0f5f53a07R52-R58): Added route rules to proxy requests to `https://stickerly.pstatic.net/**` and cache responses for 1 hour.

### Response formatting enhancements:
* [`server/utils/responseFormatter.ts`](diffhunk://#diff-6c1d95f061afc61ad068cfcde2964cd2190e83004c426b16f058c11fcf551cedR34-R66): Introduced a `replaceStickerlyUrls` helper function to recursively replace `https://stickerly.pstatic.net/` URLs with a relative path (`file/`) using the `NUXT_PUBLIC_SITE_URL` environment variable. Updated the formatter to apply this transformation to `data`, `meta`, and `errors` properties in the response.